### PR TITLE
Fix typo on React04 challenge test case

### DIFF
--- a/src/challenges/react/curriculum/React_04.js
+++ b/src/challenges/react/curriculum/React_04.js
@@ -71,7 +71,7 @@ export const executeTests = (code) => {
 		{
 			test: 2,
 			status: false,
-			condition: 'The div contains an h1 tag as the second element.'
+			condition: 'The div contains an h1 tag as the first element.'
 		},
 		{
 			test: 3,


### PR DESCRIPTION
Changed displayed test case 2 from `The div contains an h1 tag as the second element.` to `The div contains an h1 tag as the first element.`